### PR TITLE
bump version to 1.0.0

### DIFF
--- a/lib/circumstance/version.rb
+++ b/lib/circumstance/version.rb
@@ -1,3 +1,3 @@
 class Circumstance
-  VERSION = "0.0.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Going with the Gem bump. I think `1.0.0` makes sense since we're making a breaking change by renaming things, and should probably have a `1.0` release at this point